### PR TITLE
fix: export `z` with `Zompt`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zompt",
-  "version": "1.1.1",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zompt",
-      "version": "1.1.1",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ import { type LogOptions } from './objects/LogOptions';
 import { type LogType } from './objects/LogType';
 import { type PromptOptions } from './objects/PromptOptions';
 
+export { z };
+
 export class Zompt {
   configuration: Configuration;
   history: string[] = [];


### PR DESCRIPTION
Since `Zompt` already has `zod` as a dependency, exporting `z` along with it ensures compatibility and eliminates the need for users to install `zod`.